### PR TITLE
Corrected some parts in nodes and nodepools

### DIFF
--- a/source/includes/_clusters.md
+++ b/source/includes/_clusters.md
@@ -256,7 +256,7 @@ platform | string | Linux distribution to use. Options are:
  | | Azure: `coreos`, `ubuntu`
  | | DigitalOcean: `coreos`, `ubuntu`
  | | GCE: `coreos`, `ubuntu`
- | | GKE: `gci`
+ | | GKE: `gci` (send gci for "cos" as well)
 channel | string | Distribution version to use. Options are:
  | | CoreOS: `stable`, `beta`, `alpha`
  | | Ubuntu: `16.04-lts`

--- a/source/includes/_nodepools.md
+++ b/source/includes/_nodepools.md
@@ -120,7 +120,12 @@ Parameter | Type | Description
 name | string | Name of the nodepool
 instance_size | string | Instance size for the nodes. Consult provider documentation for available instance sizes.
 node_count | integer | Number of nodes to add
-role | string | Type of nodes. Only valid value: `worker`
+platform | string | Linux distribution to use. Options are:
+ | | AWS: `coreos`, `ubuntu`
+ | | Azure: `coreos`, `ubuntu`
+ | | DigitalOcean: `coreos`, `ubuntu`
+ | | GCE: `coreos`, `ubuntu`
+ | | GKE: `gci` (send gci for "cos" as well)
 zone | string | The zone where the node should be added. Valid only for master nodes on AWS
 provider_subnet_id | string | ID of Subnet where node should be added. Valid only for master nodes on AWS
 provider_subnet_cidr | string | Subnet CIDR. Valid only for master nodes on AWS
@@ -143,7 +148,7 @@ curl --header "Authorization: Bearer d0bf933f1a9f2c04f99e4bc713289fbb35abb3a5" \
     "name": "Awesome Node Pool",
     "instance_size": "n1-standard-2",
     "node_count": 4,
-    "role": "worker"
+    "platform": "coreos"
 }
 ```
 

--- a/source/includes/_nodes.md
+++ b/source/includes/_nodes.md
@@ -177,7 +177,7 @@ curl --header "Authorization: Bearer d0bf933f1a9f2c04f99e4bc713289fbb35abb3a5" \
 ```json
 {
     "node_count": 1,
-    "size": "2gb"
+    "size": "2gb",
     "role": "master"
 }
 ```
@@ -207,7 +207,7 @@ curl --header "Authorization: Bearer d0bf933f1a9f2c04f99e4bc713289fbb35abb3a5" \
 ```json
 {
     "node_count": 3,
-    "size": "2gb",
+    "size": "2gb"
 }
 ```
 

--- a/source/includes/_nodes.md
+++ b/source/includes/_nodes.md
@@ -178,6 +178,7 @@ curl --header "Authorization: Bearer d0bf933f1a9f2c04f99e4bc713289fbb35abb3a5" \
 {
     "node_count": 1,
     "size": "2gb"
+    "role": "master"
 }
 ```
 
@@ -206,11 +207,11 @@ curl --header "Authorization: Bearer d0bf933f1a9f2c04f99e4bc713289fbb35abb3a5" \
 ```json
 {
     "node_count": 3,
-    "size": "2gb"
+    "size": "2gb",
 }
 ```
 
-Add a master node to a DigitalOcean cluster.
+Add a worker node to a DigitalOcean cluster.
 
 `POST https://api.stackpoint.io/orgs/<ORG_ID>/clusters/<CLUSTER_ID>/add_node`
 


### PR DESCRIPTION
...as well as a couple other little odds and ends. I think nearly everything is current, except:

- Waiting for machine types to be implemented, then we can add that to the API docs as well
- Under node adds (for workers), if using the clusters endpoint, I left that as-is for now, but the SDK is using the nodepool endpoint to add worker nodes, so I'm not sure if this section should be removed and the user should be directed to use the nodepools endpoint, or this section should be changed to include nodepool information that is required, etc.